### PR TITLE
feat: automatic release on new tag

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,32 @@
+name: CD
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - run: yarn --frozen-lockfile
+      - run: yarn setup-ci
+      - run: yarn lint
+      - run: yarn build
+      - run: yarn zip
+      - name: changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@develop
+        with:
+          failOnError: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: release
+        uses: softprops/action-gh-release@v1
+        with:
+          fail_on_unmatched_files: true
+          body: ${{steps.build_changelog.outputs.changelog}}
+          files: dist/webext-prod/pile.zip

--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ Then, you either:
   - then import the `/dist` folder into `chrome://extensions` in your browser
 - (prod) run `yarn build`
   - then import the `/dist/webext-prod` folder into `chrome://extensions` in your browser
-  - it also generates a `pile.zip` file (in that folder) that you can upload to the chrome web store
+  - by then running `yarn zip`, you can also generates a `pile.zip` file (in that folder) that you can upload to the chrome web store
+
+# Release
+To trigger a release:
+- update the version in both `package.json` & `src/manifest.json`
+- generate a new tag following the pattern `v*.*.*`
+- the **cd** Github action should automagically generate a new release with both changelog and zip file
+- you can now upload that zip to the chrome web store, and update the changelog there
 
 # Libraries
 This project is built using:


### PR DESCRIPTION
add and document an action to generate a release when a new `v*.*.*` tag is created.
that release includes:
- release log
- release zip file