### PR TITLE
feat: publish github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,10 @@ name: CI
 
 on:
   push:
+    branches:
+      - '**'
     tags-ignore:
-      - "v*.*.*"
+      - 'v*.*.*'
 
 jobs:
   build-and-lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    tags-ignore:
+      - "v*.*.*"
 
 jobs:
   build-and-lint:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: publish
 on:
   push:
     tags:
-      - "v*.*.*"
+      - 'v*.*.*'
 
 jobs:
   publish:
@@ -20,7 +20,7 @@ jobs:
         with:
           file: src/env.json
           field: pocketKey
-          value: "${{ secrets.POCKET_KEY }}"
+          value: '${{ secrets.POCKET_KEY }}'
       - run: yarn build
       - run: yarn zip
       - name: upload

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - run: yarn --frozen-lockfile
+      - run: yarn setup-ci
+      - name: update env.json pocketKey
+        uses: jossef/action-set-json-field@v1
+        with:
+          file: src/env.json
+          field: pocketKey
+          value: "${{ secrets.POCKET_KEY }}"
+      - run: yarn build
+      - run: yarn zip
+      - name: upload
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/webext-prod/pile.zip
+          tag: ${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Then, you either:
   - then import the `/dist` folder into `chrome://extensions` in your browser
 - (prod) run `yarn build`
   - then import the `/dist/webext-prod` folder into `chrome://extensions` in your browser
-  - it also generates a `pile.zip` file (in that folder) that you can upload to the chrome web store
+  - by then running `yarn zip`, you can also generates a `pile.zip` file (in that folder) that you can upload to the chrome web store
 
 # Libraries
 This project is built using:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pile",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": "Emmanuel Krebs <e-krebs@users.noreply.github.com>",
   "license": "MIT",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "pile",
   "description": "pile",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "icons": {
     "16": "./content/icons/icon-16.png",
     "48": "./content/icons/icon-48.png",


### PR DESCRIPTION
- create a new "publish" github action
  - on release + tag creation
  - build `pile.zip`
  - attaches `pile.zip` to the release
- prevent build-and-lint to trigger on tag creation
- update REAMDE
- v1.1.0