### PR TITLE
feat: implement dependency caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: yarn-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --frozen-lockfile
       - run: yarn setup-ci
       - run: yarn lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,10 @@ jobs:
         run: |
           echo "invalid package version, expected: ${{env.new_release_version}}, got: ${{steps.package.outputs.prop}}"
           exit 1
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: yarn-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --frozen-lockfile
       - run: yarn setup-ci
       - name: update env.json pocketKey


### PR DESCRIPTION
fixes #38 

For both `ci` and `publish` workflows, implement dependency caching.
[see documentation here](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows).