### PR TITLE
Fix/empty title

### DIFF
--- a/src/components/List/Item/ItemComponent.tsx
+++ b/src/components/List/Item/ItemComponent.tsx
@@ -2,6 +2,7 @@ import cx from 'classnames';
 import type { FC } from 'react';
 
 import { getRgba } from 'utils/palette';
+import { beautifyUrl } from 'utils/url';
 import { Link } from 'components/Link';
 import { MainIcon } from './MainIcon';
 import { Chevron } from './Chevron';
@@ -27,7 +28,7 @@ export const ItemComponent: FC = () => {
             <Link
               className={cx('grow pt-0.5 hover:text-inherit', !isOpen && 'truncate')}
               url={url}
-              title={`${url} – ${title}`}
+              title={`${beautifyUrl(url)} – ${title}`}
             >
               {title}
             </Link>

--- a/src/services/pocket/item.ts
+++ b/src/services/pocket/item.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from 'utils/string';
 import { ListItem } from 'utils/typings';
+import { beautifyUrl } from 'utils/url';
 
 export interface PocketItem {
   domain_metadata?: {
@@ -19,10 +20,16 @@ export interface PocketItem {
   tags?: Record<string, Record<string, unknown>>;
 }
 
-export const itemToListItem = (item: PocketItem): ListItem => ({
-  id: item.item_id,
-  title: isEmpty(item.given_title) ? item.given_title : item.resolved_title,
-  url: isEmpty(item.given_url) ? item.given_url : item.resolved_url,
-  logo: item.domain_metadata?.logo,
-  tags: item.tags ? Object.keys(item.tags).sort() : [],
-});
+export const itemToListItem = (item: PocketItem): ListItem => {
+  const url = isEmpty(item.given_url) ? item.given_url : item.resolved_url;
+  let title = isEmpty(item.given_title) ? item.given_title : item.resolved_title;
+  if (!title) title = beautifyUrl(url);
+
+  return {
+    id: item.item_id,
+    title,
+    url,
+    logo: item.domain_metadata?.logo,
+    tags: item.tags ? Object.keys(item.tags).sort() : [],
+  };
+};

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,2 @@
+export const beautifyUrl = (url: string): string =>
+  url.replace(/^http(?:s)?:\/\/(www.)?/, '').replace(/\/$/, '');


### PR DESCRIPTION
fixes #86 

- add helper to beautify `url`
- item title fallsback to beautified url
- item link title uses beautified url instead of raw url