### PR TITLE
chore(security): update jpeg-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "utils": "./src/utils"
   },
   "resolutions": {
+    "jpeg-js": ">= 0.4.4",
     "json-schema": ">= 0.4.0",
     "nth-check": ">= 2.0.1",
     "node-forge": ">= 1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3320,10 +3320,10 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-jpeg-js@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.2.tgz#8b345b1ae4abde64c2da2fe67ea216a114ac279d"
-  integrity sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==
+jpeg-js@0.4.2, "jpeg-js@>= 0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
+  integrity sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==
 
 js-sha3@0.8.0:
   version "0.8.0"


### PR DESCRIPTION
[CVE-2022-25851](https://cwe.mitre.org/data/definitions/835.html)