### PR TITLE
feat: remember last tag when opening pile's menu

### DIFF
--- a/src/components/List/ListContext.ts
+++ b/src/components/List/ListContext.ts
@@ -3,7 +3,7 @@ import { createContext, useContext } from 'react';
 interface List {
   allTags: string[];
   tag?: string | null;
-  setTag: (tag?: string | null) => void;
+  setTag: (tag?: string | null) => Promise<void>;
   searchTerm: string | null;
   setSearchTerm: (string: string | null) => void;
   setItemOpen: (id: string | null) => void;

--- a/src/components/List/TagFilter.tsx
+++ b/src/components/List/TagFilter.tsx
@@ -17,18 +17,18 @@ export const TagFilter: FC<TagFilterProps> = ({ tagOpen, openTag }) => {
 
   const hasTag: boolean = useMemo(() => !tagOpen && tag !== undefined, [tag, tagOpen]);
 
-  const onTag = (value?: string | null) => {
+  const onTag = async (value?: string | null) => {
     switch (value) {
       case undefined:
       case 'undefined':
-        setTag();
+        await setTag();
         break;
       case null:
       case 'null':
-        setTag(null);
+        await setTag(null);
         break;
       default:
-        setTag(value);
+        await setTag(value);
         break;
     }
     openTag(false);

--- a/src/utils/lastTag.ts
+++ b/src/utils/lastTag.ts
@@ -1,0 +1,14 @@
+const getLastTagKey = (serviceName: string) => `${serviceName}-last-tag`;
+
+export const getLastTag = async (serviceName: string): Promise<string | null | undefined> => {
+  const key = getLastTagKey(serviceName);
+  const value = await chrome.storage.local.get();
+  return value ? value[key] : undefined;
+};
+
+export const setLastTag = async (serviceName: string, tag: string | null | undefined): Promise<void> => {
+  const key = getLastTagKey(serviceName);
+  tag === undefined
+    ? await chrome.storage.local.remove(key)
+    : await chrome.storage.local.set({ [key]: tag });
+};


### PR DESCRIPTION
using `storage.local` to save the last opened tag (or non when closed)
& using it again on opening