### PR TITLE
fix: remember when the last selected tag was 'untagged'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pile",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "author": "Emmanuel Krebs <e-krebs@users.noreply.github.com>",
   "license": "MIT",
   "scripts": {

--- a/src/helpers/localstorage.ts
+++ b/src/helpers/localstorage.ts
@@ -20,7 +20,7 @@ export const deleteLocalStorageValue = async <T extends string>(
 
 export const getFromLocalStorage = async <T>(key: string): Promise<T | undefined> => {
   const value = await chrome.storage.local.get(key);
-  if (!value || !value[key]) return undefined;
+  if (!value || value[key] === undefined) return undefined;
   return value[key] as T;
 };
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "pile",
   "description": "pile",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "icons": {
     "16": "./content/icons/icon-16.png",
     "48": "./content/icons/icon-48.png",

--- a/src/utils/lastTag.ts
+++ b/src/utils/lastTag.ts
@@ -3,7 +3,7 @@ import { getFromLocalStorage, setToLocalStorage, deleteFromLocalStorage } from '
 const getLastTagKey = (serviceName: string) => `${serviceName}-last-tag`;
 
 export const getLastTag = async (serviceName: string): Promise<string | null | undefined> =>
-  await getFromLocalStorage<string>(getLastTagKey(serviceName));
+  await getFromLocalStorage<string | null>(getLastTagKey(serviceName));
 
 export const setLastTag = async (serviceName: string, tag: string | null | undefined): Promise<void> => {
   tag === undefined


### PR DESCRIPTION
closes #148 

- when LocalStorage value is `null`, return `null` instead of `undefined`
- fix typing for `getLastTag` method
- v1.9.2