### PR TITLE
feat: scroll into view item matching the active tab (if any) when opening the popup/switching tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pile",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "author": "Emmanuel Krebs <e-krebs@users.noreply.github.com>",
   "license": "MIT",
   "scripts": {

--- a/src/components/List/Item/ItemComponent.tsx
+++ b/src/components/List/Item/ItemComponent.tsx
@@ -15,10 +15,14 @@ import { useService } from 'hooks';
 export const ItemComponent: FC<RefAttributes<HTMLDivElement>> = forwardRef<HTMLDivElement>(
   function ItemComponent(_, ref) {
     const { isUpdatable } = useService();
-    const { url, title, rgb, isOpen } = useItemContext();
+    const { url, title, rgb, isOpen, isActive } = useItemContext();
 
     return (
-      <div ref={ref} className="rounded-md" style={{ backgroundColor: getRgba(rgb, 0.1) }}>
+      <div
+        ref={ref}
+        className={cx('rounded-md', isActive && 'border border-green-500')}
+        style={{ backgroundColor: getRgba(rgb, 0.1) }}
+      >
         <div
           className={cx(
             'rounded-md py-2 hover:bg-inherit',

--- a/src/components/List/Item/ItemComponent.tsx
+++ b/src/components/List/Item/ItemComponent.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import type { FC } from 'react';
+import { RefAttributes, forwardRef, type FC } from 'react';
 
 import { getRgba } from 'utils/palette';
 import { beautifyUrl } from 'utils/url';
@@ -12,41 +12,45 @@ import { ArchiveAction } from './ArchiveAction';
 import { Tags } from './Tags';
 import { useService } from 'hooks';
 
-export const ItemComponent: FC = () => {
-  const { isUpdatable } = useService();
-  const { url, title, rgb, isOpen } = useItemContext();
+export const ItemComponent: FC<RefAttributes<HTMLDivElement>> = forwardRef<HTMLDivElement>(
+  function ItemComponent(_, ref) {
+    const { isUpdatable } = useService();
+    const { url, title, rgb, isOpen } = useItemContext();
 
-  return (
-    <div className="rounded-md" style={{ backgroundColor: getRgba(rgb, 0.1) }}>
-      <div
-        className={cx(
-          'rounded-md py-2 hover:bg-inherit',
-          isOpen ? 'bg-inherit' : 'bg-white dark:bg-gray-900'
-        )}
-      >
-        <div className="flex items-start space-x-4 pl-2">
-          <MainIcon />
-          <div className={cx('flex grow items-baseline space-x-2 overflow-auto')}>
-            <Link
-              className={cx('grow pt-0.5 hover:text-inherit', !isOpen && 'truncate')}
-              url={url}
-              title={`${beautifyUrl(url)} – ${title}`}
+    return (
+      <div ref={ref} className="rounded-md" style={{ backgroundColor: getRgba(rgb, 0.1) }}>
+        <div
+          className={cx(
+            'rounded-md py-2 hover:bg-inherit',
+            isOpen ? 'bg-inherit' : 'bg-white dark:bg-gray-900'
+          )}
+        >
+          <div className="flex items-start space-x-4 pl-2">
+            <MainIcon />
+            <div className={cx('flex grow items-baseline space-x-2 overflow-auto')}>
+              <Link
+                className={cx('grow pt-0.5 hover:text-inherit', !isOpen && 'truncate')}
+                url={url}
+                title={`${beautifyUrl(url)} – ${title}`}
+              >
+                {title}
+              </Link>
+              <Tags />
+            </div>
+            <Chevron />
+          </div>
+          {isUpdatable && (
+            <div
+              className={cx('flex px-2 transition-height', isOpen ? 'visible h-10' : 'invisible h-0')}
             >
-              {title}
-            </Link>
-            <Tags />
-          </div>
-          <Chevron />
+              <div className="grow" />
+              <DeleteAction />
+              <ArchiveAction />
+              <div className="h-8 w-8 shrink-0" />
+            </div>
+          )}
         </div>
-        {isUpdatable && (
-          <div className={cx('flex px-2 transition-height', isOpen ? 'visible h-10' : 'invisible h-0')}>
-            <div className="grow" />
-            <DeleteAction />
-            <ArchiveAction />
-            <div className="h-8 w-8 shrink-0" />
-          </div>
-        )}
       </div>
-    </div>
-  );
-};
+    );
+  }
+);

--- a/src/components/List/Item/ItemContext.ts
+++ b/src/components/List/Item/ItemContext.ts
@@ -13,6 +13,7 @@ interface Item {
   setIsOpen: (value: boolean) => void;
   isAddTagsOpen: boolean;
   setIsAddTagsOpen: (value: boolean) => void;
+  isActive: boolean;
 }
 
 export const ItemContext = createContext<Item | null>(null);

--- a/src/components/List/Item/index.tsx
+++ b/src/components/List/Item/index.tsx
@@ -10,9 +10,15 @@ interface ItemProps {
   item: ListItem;
   isOpen: boolean;
   isAddTagsOpen: boolean;
+  isActive: boolean;
 }
 
-export const Item: FC<ItemProps> = ({ item: { id, title, url, logo, tags }, isOpen, isAddTagsOpen }) => {
+export const Item: FC<ItemProps> = ({
+  item: { id, title, url, logo, tags },
+  isOpen,
+  isAddTagsOpen,
+  isActive,
+}) => {
   const { setItemOpen, setAddTagsItemOpen } = useListContext();
   const [icon, setIcon] = useState<IconAndPalette>();
 
@@ -37,6 +43,7 @@ export const Item: FC<ItemProps> = ({ item: { id, title, url, logo, tags }, isOp
         setIsOpen: (value: boolean) => setItemOpen(value ? id : null),
         isAddTagsOpen,
         setIsAddTagsOpen: (value: boolean) => setAddTagsItemOpen(value ? id : null),
+        isActive,
       }}
     >
       <ItemComponent />

--- a/src/components/List/Item/index.tsx
+++ b/src/components/List/Item/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 
 import { getIcon, IconAndPalette } from 'utils/icon';
 import { ListItem } from 'utils/typings';
@@ -22,6 +22,8 @@ export const Item: FC<ItemProps> = ({
   const { setItemOpen, setAddTagsItemOpen } = useListContext();
   const [icon, setIcon] = useState<IconAndPalette>();
 
+  const ref = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     const effect = async () => {
       const iconAndPalette = await getIcon(new URL(url).hostname, logo);
@@ -29,6 +31,12 @@ export const Item: FC<ItemProps> = ({
     };
     effect();
   }, [logo, url]);
+
+  useEffect(() => {
+    if (isActive && ref?.current) {
+      ref.current.scrollIntoView({ block: 'center' });
+    }
+  }, [ref, isActive]);
 
   return (
     <ItemContext.Provider
@@ -46,7 +54,7 @@ export const Item: FC<ItemProps> = ({
         isActive,
       }}
     >
-      <ItemComponent />
+      <ItemComponent ref={ref} />
     </ItemContext.Provider>
   );
 };

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -28,7 +28,7 @@ export const List: FC = () => {
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
   const [searchOpen, setSearchOpen] = useState<boolean>(false);
   const [tagOpen, setTagOpen] = useState<boolean>(false);
-  const [itemOpen, setItemOpen] = useState<string | null>(null);
+  const [itemOpen, setItemOpen] = useState<string | null | undefined>(undefined);
   const [addTagsItemOpen, setAddTagsItemOpen] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<URL | undefined>();
@@ -195,7 +195,7 @@ export const List: FC = () => {
             <Item
               item={item}
               key={item.id}
-              isOpen={item.id === itemOpen}
+              isOpen={itemOpen !== undefined ? item.id === itemOpen : isMatching(item.url)}
               isActive={isMatching(item.url)}
               isAddTagsOpen={item.id === addTagsItemOpen}
             />

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -17,6 +17,8 @@ import { TagFilter } from './TagFilter';
 import { SearchFilter } from './SearchFilter';
 import { getAllTags } from 'utils/getAllTags';
 import { getLastTag, setLastTag } from 'utils/lastTag';
+import { getActiveTab } from 'utils/getActiveTab';
+import { urlsAreMatching } from 'utils/currentUrlIsMatching';
 
 export const List: FC = () => {
   const service = useService();
@@ -29,12 +31,26 @@ export const List: FC = () => {
   const [itemOpen, setItemOpen] = useState<string | null>(null);
   const [addTagsItemOpen, setAddTagsItemOpen] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<URL | undefined>();
   const [tag, setTagLocal] = useState<string | null | undefined>();
   const { data } = useQuery(service.getQueryKey, async () => {
     const list = await get(service);
     setBadge(service.name, list.data.length);
     return list;
   });
+
+  useEffect(() => {
+    const initActiveTab = async () => {
+      const url = await getActiveTab();
+      setActiveTab(url ? new URL(url) : undefined);
+    };
+    initActiveTab();
+  }, []);
+
+  const isMatching = useCallback(
+    (url: string) => activeTab !== undefined && urlsAreMatching(new URL(url), activeTab),
+    [activeTab]
+  );
 
   useEffect(() => {
     const getTagOnInit = async () => {
@@ -180,6 +196,7 @@ export const List: FC = () => {
               item={item}
               key={item.id}
               isOpen={item.id === itemOpen}
+              isActive={isMatching(item.url)}
               isAddTagsOpen={item.id === addTagsItemOpen}
             />
           ))}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "pile",
   "description": "pile",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "icons": {
     "16": "./content/icons/icon-16.png",
     "48": "./content/icons/icon-48.png",


### PR DESCRIPTION
closes #135 

When opening the popup (& when switching tabs), if an item is matching the active tab:
- scroll it into view
- open it
- add a green border around it (same color as the green pile icon)